### PR TITLE
PB-502 - Remove AWS secret refs, set default docker registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,7 @@ env:
   GO_VERSION: '1.17'
   GOLANGCI_VERSION: 'v1.31'
   DOCKER_BUILDX_VERSION: 'v0.4.2'
-
-  # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
-  # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
-  # credentials have been provided before trying to run steps that need them.
   DOCKER_USR: ${{ secrets.DOCKER_USR }}
-  AWS_USR: ${{ secrets.AWS_USR }}
-
   DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
 
 jobs:
@@ -302,18 +296,13 @@ jobs:
       
       - name: Publish Artifacts to S3 and Docker Hub
         run: make -j2 publish BRANCH_NAME=${GITHUB_REF##*/}
-        if: env.AWS_USR != '' && env.DOCKER_USR != ''
+        if: env.DOCKER_USR != ''
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
           GIT_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Promote Artifacts in S3 and Docker Hub
-        if: github.ref == 'refs/heads/main' && env.AWS_USR != '' && env.DOCKER_USR != ''
+        if: github.ref == 'refs/heads/main' && env.DOCKER_USR != ''
         run: make -j2 promote
         env:
           BRANCH_NAME: main
           CHANNEL: main
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
-        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,7 @@ jobs:
         uses: docker/login-action@v1
         if: env.DOCKER_USR != ''
         with:
+          registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ secrets.DOCKER_USR }}
           password: ${{ secrets.DOCKER_PSW }}
       

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -11,13 +11,6 @@ on:
         required: true
         default: 'alpha'
 
-env:
-  # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
-  # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
-  # credentials have been provided before trying to run steps that need them.
-  DOCKER_USR: ${{ secrets.DOCKER_USR }}
-  AWS_USR: ${{ secrets.AWS_USR }}
-
 jobs:
   promote-artifacts:
     runs-on: ubuntu-18.04
@@ -39,10 +32,8 @@ jobs:
           password: ${{ secrets.DOCKER_PSW }}
 
       - name: Promote Artifacts in S3 and Docker Hub
-        if: env.AWS_USR != '' && env.DOCKER_USR != ''
+        if: env.DOCKER_USR != ''
         run: make -j2 promote BRANCH_NAME=${GITHUB_REF##*/}
         env:
           VERSION: ${{ github.event.inputs.version }}
           CHANNEL: ${{ github.event.inputs.channel }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ GO111MODULE = on
 # ====================================================================================
 # Setup Images
 
-DOCKER_REGISTRY ?= crossplane
+DOCKER_REGISTRY ?= baas.jfrog.io
 IMAGES = provider-github provider-github-controller
 -include build/makelib/image.mk
 


### PR DESCRIPTION
### Description of your changes

Sets the fallback registry to baas artifactory
Removes AWS OCI refs
Additionally, secrets have been configured within the repository for Artifactory access
